### PR TITLE
Remove "<2.7" constraint on symfony/console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0",
     "composer/composer": "1.0.0-beta1",
-    "symfony/console": "~2.3"
+    "symfony/console": "~2.3, !=2.7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.1.0"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0",
     "composer/composer": "1.0.0-beta1",
-    "symfony/console": "~2.3 <2.7"
+    "symfony/console": "~2.3"
   },
   "require-dev": {
     "phpunit/phpunit": "4.1.0"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "magento/composer",
   "description": "Magento composer library helps to instantiate Composer application and run composer commands.",
   "type": "library",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": [
     "OSL-3.0",
     "AFL-3.0"


### PR DESCRIPTION
Updated dependency on symfony/console to remote limitation <2.7
Updated minor version of magento/composer due to new dependency on symfony/console